### PR TITLE
removed ?v=pretty as it is not valid anymore

### DIFF
--- a/vApus.Monitor.Sources.Elasticsearch/ElasticsearchNode.cs
+++ b/vApus.Monitor.Sources.Elasticsearch/ElasticsearchNode.cs
@@ -61,8 +61,8 @@ namespace vApus.Monitor.Sources.Elasticsearch {
 
         public override string Config {
             get {
-                _jvMaster = GetBody("_cat/master?v=pretty");
-                _jvShards = GetBody("_cat/shards?v=pretty");
+                _jvMaster = GetBody("_cat/master?v");
+                _jvShards = GetBody("_cat/shards?v");
 
                 return "Master\n" + _jvMaster + "\n\nShards\n" + _jvShards;
             }
@@ -92,8 +92,8 @@ namespace vApus.Monitor.Sources.Elasticsearch {
             try {
                 var entities = Entities;
 
-                _jvMaster = GetBody("_cat/master?v=pretty");
-                _jvShards = GetBody("_cat/shards?v=pretty");
+                _jvMaster = GetBody("_cat/master?v");
+                _jvShards = GetBody("_cat/shards?v");
 
                 _connected = true;
             }
@@ -277,7 +277,7 @@ namespace vApus.Monitor.Sources.Elasticsearch {
 
             JsonValue jvStats = GetJSONObject("_nodes/stats")["nodes"];
             string[] jvMaster = GetBody("_cat/master").Split(' ');
-            _jvShards = GetBody("_cat/shards?v=pretty");
+            _jvShards = GetBody("_cat/shards?v");
 
             List<CounterInfo> shardscis = null;
             ConcurrentBag<CounterInfo> statscis = null;


### PR DESCRIPTION
When trying to query to an URL (e.g.: /_cat/master?v=pretty) the following error occurs:
`{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Failed to parse value [pretty] as only [true] or [false] are allowed."}],"type":"illegal_argument_exception","reason":"Failed to parse value [pretty] as only [true] or [false] are allowed."},"status":400}`

So now it is fixed to the default (true)